### PR TITLE
Fix Airtable authentication in curl workflow

### DIFF
--- a/.github/workflows/airtable-sql-sync-curl.yml
+++ b/.github/workflows/airtable-sql-sync-curl.yml
@@ -24,8 +24,19 @@ jobs:
         npm install mssql dotenv
     
     - name: Export Airtable data using curl
+      env:
+        AIRTABLE_PAT: ${{ secrets.AIRTABLE_PAT }}
       run: |
         echo "📥 Fetching projects from Airtable using curl..."
+        
+        # Debug: Check if token is set
+        if [ -z "$AIRTABLE_PAT" ]; then
+          echo "❌ ERROR: AIRTABLE_PAT is not set!"
+          exit 1
+        fi
+        
+        echo "✅ AIRTABLE_PAT is set (length: ${#AIRTABLE_PAT})"
+        echo "🔍 Token starts with: ${AIRTABLE_PAT:0:10}..."
         
         # Initialize variables
         ALL_RECORDS="[]"
@@ -40,7 +51,8 @@ jobs:
             URL="https://api.airtable.com/v0/appkYMgaK0cHVu4Zg/Projects?pageSize=100&offset=$OFFSET"
           fi
           
-          RESPONSE=$(curl -s "$URL" -H "Authorization: Bearer ${{ secrets.AIRTABLE_PAT }}")
+          echo "🔗 Calling: $URL"
+          RESPONSE=$(curl -s "$URL" -H "Authorization: Bearer $AIRTABLE_PAT")
           
           # Check for errors
           if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then


### PR DESCRIPTION
The workflow was failing because the AIRTABLE_PAT secret wasn't being passed as an environment variable. This PR fixes that and adds debugging to help diagnose any remaining issues.